### PR TITLE
fix load_avg error 

### DIFF
--- a/src/threads/thread.c
+++ b/src/threads/thread.c
@@ -84,6 +84,7 @@ static tid_t allocate_tid (void);
 
    It is not safe to call thread_current() until this function
    finishes. */
+int load_avg  ; // declare a global var to be initialize in run time 
 void
 thread_init (void) 
 {

--- a/src/threads/thread.h
+++ b/src/threads/thread.h
@@ -116,7 +116,8 @@ struct thread
    If true, use multi-level feedback queue scheduler.
    Controlled by kernel command-line option "-o mlfqs". */
 extern bool thread_mlfqs;
-int load_avg; /*ADDED*/
+extern int load_avg; /*ADDED*/
+// just added extern to avoid redefine the variable
 
 void thread_init (void);
 void thread_start (void);


### PR DESCRIPTION
-  added extern to the` thread.h `file 
     `extern int load_avg; /*ADDED*/`
- added a global variable in `thread.c  `file  
`   int load_avg  `